### PR TITLE
Hotfix/issue6 sast9.0 login

### DIFF
--- a/Configuration/Configuration.csproj
+++ b/Configuration/Configuration.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/Configuration/CxAnalyticsService.cs
+++ b/Configuration/CxAnalyticsService.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace CxAnalytix.Configuration
 {
-    public sealed class CxAnalyticsService : ConfigurationSection
+    public sealed class CxAnalyticsService : EnvAwareConfigurationSection
     {
         internal CxAnalyticsService ()
         {

--- a/Configuration/CxConnection.cs
+++ b/Configuration/CxConnection.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace CxAnalytix.Configuration
 {
-    public sealed class CxConnection : ConfigurationSection
+    public sealed class CxConnection : EnvAwareConfigurationSection
     {
         internal CxConnection ()
         {

--- a/Configuration/CxCredentials.cs
+++ b/Configuration/CxCredentials.cs
@@ -7,7 +7,7 @@ using System.Xml.Serialization;
 
 namespace CxAnalytix.Configuration
 {
-    public sealed class CxCredentials : ConfigurationSection
+    public sealed class CxCredentials : EnvAwareConfigurationSection
     {
         internal CxCredentials ()
         {

--- a/Configuration/EnvAwareConfigurationSection.cs
+++ b/Configuration/EnvAwareConfigurationSection.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Configuration;
+
+
+namespace CxAnalytix.Configuration
+{
+    public class EnvAwareConfigurationSection : ConfigurationSection
+    {
+        protected new object this[string propertyName]
+        {
+            get
+            {
+                object retVal = base[propertyName];
+
+                if (retVal.GetType() == typeof(String))
+                    return Environment.ExpandEnvironmentVariables((String)retVal);
+
+                return retVal;
+            }
+
+            set
+            {
+                base[propertyName] = value;
+            }
+        }
+    }
+}

--- a/CxAnalytixCLI/Properties/launchSettings.json
+++ b/CxAnalytixCLI/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "CxAnalytixCLI": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/CxRestClient/CxProjects.cs
+++ b/CxRestClient/CxProjects.cs
@@ -33,7 +33,7 @@ namespace CxRestClient
         public class Project
         {
             [JsonProperty(PropertyName = "teamId")]
-            public Guid TeamId { get; internal set; }
+            public String TeamId { get; internal set; }
             public int PresetId { get; internal set; }
             [JsonProperty(PropertyName = "id")]
             public int ProjectId { get; internal set; }

--- a/CxRestClient/CxTeams.cs
+++ b/CxRestClient/CxTeams.cs
@@ -33,7 +33,7 @@ namespace CxRestClient
 
             public Team Current => new Team()
             {
-                TeamId = new Guid(((JProperty)_reader.CurrentToken).Value.ToString()),
+                TeamId = ((JProperty)_reader.CurrentToken).Value.ToString(),
                 TeamName = ((JProperty)_reader.CurrentToken.Next).Value.ToString()
             };
 
@@ -74,7 +74,7 @@ namespace CxRestClient
 
         public struct Team
         {
-            public Guid TeamId { get; internal set; }
+            public String TeamId { get; internal set; }
             public String TeamName { get; internal set; }
         }
 

--- a/TransformLogic/Data/ProjectDescriptor.cs
+++ b/TransformLogic/Data/ProjectDescriptor.cs
@@ -45,9 +45,9 @@ namespace CxAnalytix.TransformLogic.Data
         /// </summary>
         public String ProjectName { get; set; }
         /// <summary>
-        /// The GUID that identifies the team that owns the project.
+        /// The GUID or integer that identifies the team that owns the project.
         /// </summary>
-        public Guid TeamId { get; set; }
+        public String TeamId { get; set; }
         /// <summary>
         /// A human-readable name for the team.
         /// </summary>

--- a/TransformLogic/DataResolver.cs
+++ b/TransformLogic/DataResolver.cs
@@ -41,21 +41,21 @@ namespace CxAnalytix.TransformLogic
             return !_disallowAdd;
         }
 
-        internal Dictionary<Guid, String> Teams { get => _teams; }
+        internal Dictionary<String, String> Teams { get => _teams; }
 
-        private Dictionary<Guid, String> _teams = new Dictionary<Guid, string>();
+        private Dictionary<String, String> _teams = new Dictionary<String, String>();
         /// <summary>
         /// The method use to load the list of teams into memory for resolution
         /// when the Resolve method is called.
         /// </summary>
-        /// <param name="teamId">The GUID team identifier.</param>
+        /// <param name="teamId">The GUID or integer team identifier.</param>
         /// <param name="teamName">The name of the team.</param>
         /// <returns>True if the team was added, false otherwise.</returns>
         /// <see cref="DataResolver.Resolve(StreamReader, StreamWriter)"/>
         /// <see cref="DataResolver.Resolve(string)"/>
-        public bool addTeam (Guid teamId, String teamName)
+        public bool addTeam (String teamId, String teamName)
         {
-            if (teamId == Guid.Empty || teamName == null)
+            if (String.IsNullOrEmpty (teamId) || String.IsNullOrEmpty(teamName) )
                 return false;
 
             if (!_disallowAdd)

--- a/TransformLogic/ProjectResolver.cs
+++ b/TransformLogic/ProjectResolver.cs
@@ -176,7 +176,7 @@ namespace CxAnalytix.TransformLogic
         /// <param name="projectId">The numeric project identifier.</param>
         /// <param name="projectName">The name of the project.</param>
         /// <returns>True of the project was added, false otherwise.</returns>
-        public bool AddProject(Guid teamId, int presetId, int projectId, String projectName, 
+        public bool AddProject(String teamId, int presetId, int projectId, String projectName, 
             String policies, IDictionary<String, String> customFields)
         {
             if (projectName == null)

--- a/TransformLogic_Tests/DataResolverTests.cs
+++ b/TransformLogic_Tests/DataResolverTests.cs
@@ -19,11 +19,11 @@ namespace Test.TransformerLogic.DataResolver
         [Test]
         public void CantAddTeamPostResolve ()
         {
-            bool shouldBeTrue = d.addTeam(Guid.NewGuid(), "Foo");
+            bool shouldBeTrue = d.addTeam(Guid.NewGuid().ToString (), "Foo");
 
             var r = d.Resolve(null);
 
-            bool shouldBeFalse = d.addTeam(Guid.NewGuid(), "Bar");
+            bool shouldBeFalse = d.addTeam(Guid.NewGuid().ToString(), "Bar");
 
             Assert.True(shouldBeTrue && !shouldBeFalse);
 
@@ -53,13 +53,13 @@ namespace Test.TransformerLogic.DataResolver
         [Test]
         public void CantAddTeamWithNullName ()
         {
-            Assert.False(d.addTeam(Guid.NewGuid (), null));
+            Assert.False(d.addTeam(Guid.NewGuid ().ToString(), null));
         }
 
         [Test]
         public void CantAddTeamWithEmptyGuid ()
         {
-            Assert.False(d.addTeam(Guid.Empty, String.Empty));
+            Assert.False(d.addTeam(String.Empty, String.Empty));
         }
 
         [Test]

--- a/TransformLogic_Tests/ProjectResolverTests.cs
+++ b/TransformLogic_Tests/ProjectResolverTests.cs
@@ -16,8 +16,8 @@ namespace Test.TransformerLogic.ProjectResolver
                 { "dummy", (d, t) => {} }
         };
 
-        Guid Team1 = Guid.NewGuid();
-        Guid Team2 = Guid.NewGuid();
+        String Team1 = "1";
+        String Team2 = "2";
 
         [SetUp]
         public void SetupTest ()
@@ -68,13 +68,13 @@ namespace Test.TransformerLogic.ProjectResolver
         [Test]
         public void CantAddProjectWithMissingTeam()
         {
-            Assert.False(pr.AddProject(Guid.NewGuid(), 1, 1, "Foo", "", new Dictionary<String, String>()));
+            Assert.False(pr.AddProject(Guid.NewGuid().ToString(), 1, 1, "Foo", "", new Dictionary<String, String>()));
         }
 
         [Test]
         public void CantAddProjectWithEmptyTeamGuid()
         {
-            Assert.False(pr.AddProject(Guid.Empty, 1, 1, "Foo", "", new Dictionary<String, String>()));
+            Assert.False(pr.AddProject(Guid.Empty.ToString(), 1, 1, "Foo", "", new Dictionary<String, String>()));
         }
 
         [Test]

--- a/TransformLogic_Tests/ScanResolverTests.cs
+++ b/TransformLogic_Tests/ScanResolverTests.cs
@@ -21,8 +21,8 @@ namespace Test.TransformerLogic.ScanResolver
         };
 
 
-        Guid Team1 = Guid.NewGuid();
-        Guid Team2 = Guid.NewGuid();
+        String Team1 = "1";
+        String Team2 = "2";
 
         MemoryStream stateStorage;
         StreamWriter stateWriter;


### PR DESCRIPTION


### Description

Fixes SAST 9.0 API compatibility issue.  It was not a login issue, it was failing due to Team Ids changing to integers in 9.0.

Also added enhancement to resolve environment variables in appropriate configuration XML elements.

### References

Fixes #6 
Resolves #9 

Wiki docs are updated to reflect environment variable expansion.

### Testing

Tested against 8.9 and 9.0 instances to verify compatibility.  Team Id is not used in the data specification so output impact was minimal.  Team names are used and does change slightly between 8.9 and 9.0 due to the path separator change.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
