### PR TITLE
Hotfix/issue18 policy retrieval error

### DIFF
--- a/CxRestClient/CxRestContext.cs
+++ b/CxRestClient/CxRestContext.cs
@@ -321,7 +321,8 @@ namespace CxRestClient
                 CxRestContext retVal = new CxRestContext()
                 {
                     SastToken = GetLoginToken(_url, _user, _pass, SAST_SCOPE, _validate),
-                    MNOToken = GetLoginToken(_url, _user, _pass, MNO_SCOPE, _validate),
+                    // TODO: Test on 8.9, 8.9 no ose, 9.0 no osa
+                    MNOToken = GetLoginToken(_url, _user, _pass, $"{MNO_SCOPE} {SAST_SCOPE}", _validate),
                     Url = _url,
                     MnoUrl = _mnoUrl == null ? _url : _mnoUrl,
                     ValidateSSL = _validate,

--- a/CxRestClient/CxRestContext.cs
+++ b/CxRestClient/CxRestContext.cs
@@ -321,10 +321,9 @@ namespace CxRestClient
                 CxRestContext retVal = new CxRestContext()
                 {
                     SastToken = GetLoginToken(_url, _user, _pass, SAST_SCOPE, _validate),
-                    // TODO: Test on 8.9, 8.9 no ose, 9.0 no osa
                     MNOToken = GetLoginToken(_url, _user, _pass, $"{MNO_SCOPE} {SAST_SCOPE}", _validate),
                     Url = _url,
-                    MnoUrl = _mnoUrl == null ? _url : _mnoUrl,
+                    MnoUrl = String.IsNullOrEmpty (_mnoUrl) ? _url : _mnoUrl,
                     ValidateSSL = _validate,
                     Timeout = new TimeSpan(0, 0, _timeout)
                 };


### PR DESCRIPTION

### Description

M&O access scope prior to 8.9 needed only cxarm_api.  As of 9.0, it needs both cxarm_api and sast_rest_api due to the impersonation used by the CxARM API talking to the SAST API in a cascading web service call.

### References

Fixes #18


### Testing

Tested against 8.9 and 9.0 instances, each configured with and without M&O to ensure no break for cases where M&O is not installed.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable). 
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
