### PR TITLE
adjust non-US locale date parse issues, add Engine start/finish times

### DIFF
--- a/CxRestClient/CxSastScans.cs
+++ b/CxRestClient/CxSastScans.cs
@@ -29,6 +29,14 @@ namespace CxRestClient
             Failed
         }
 
+        public static DateTime NormalizeDateParse (String isoDate)
+        {
+            if (String.IsNullOrEmpty(isoDate))
+                return DateTime.MinValue;
+            else
+                return DateTime.Parse(isoDate);
+        }
+
         [JsonObject(MemberSerialization.OptIn)]
         public class Scan
         {
@@ -39,8 +47,10 @@ namespace CxRestClient
             internal Dictionary<String, Object> project { get; set; }
             [JsonProperty(PropertyName = "dateAndTime")]
             internal Dictionary<String, String> date_times { get; set; }
-            public DateTime StartTime { get => DateTime.Parse(date_times["startedOn"]); }
-            public DateTime FinishTime { get => DateTime.Parse(date_times["finishedOn"]); }
+            public DateTime StartTime { get => NormalizeDateParse (date_times["startedOn"]); }
+            public DateTime FinishTime { get => NormalizeDateParse (date_times["finishedOn"]); }
+            public DateTime EngineStartTime { get => NormalizeDateParse (date_times["engineStartedOn"]); }
+            public DateTime EngineFinishTime { get => NormalizeDateParse (date_times["engineFinishedOn"]); }
             [JsonProperty(PropertyName = "scanState")]
             internal Dictionary<String, Object> scan_state { get; set; }
             public int FileCount { get => Convert.ToInt32(scan_state["filesCount"]); }
@@ -128,8 +138,8 @@ namespace CxRestClient
                     if (!(_arrayPos < _scanArray.Count))
                         return false;
 
-                    _currentScan = (Scan)new JsonSerializer().
-                        Deserialize(new JTokenReader(_scanArray[_arrayPos]), typeof(Scan));
+                    _currentScan = (Scan)new JsonSerializer()
+                        .Deserialize(new JTokenReader(_scanArray[_arrayPos]), typeof(Scan));
 
                     if (_currentScan.IsPublic)
                         break;
@@ -187,6 +197,7 @@ namespace CxRestClient
                             (scans.Content.ReadAsStreamAsync().Result))
                         using (var jtr = new JsonTextReader(sr))
                         {
+                            jtr.DateParseHandling = DateParseHandling.None;
                             JToken jt = JToken.Load(jtr);
                             return new ScansReader(jt);
                         }

--- a/CxRestClient_Tests/NormalizedDateTests.cs
+++ b/CxRestClient_Tests/NormalizedDateTests.cs
@@ -1,0 +1,28 @@
+﻿using CxRestClient;
+using NUnit.Framework;
+using System;
+
+namespace CxRestClient_Tests
+{
+    public class NormalizedDateTests
+    {
+        [Test]
+        public void EmptyStringExpectMinDate ()
+        {
+            Assert.True(CxSastScans.NormalizeDateParse("").Equals (DateTime.MinValue));
+        }
+
+        [Test]
+        public void NullStringExpectMinDate()
+        {
+            Assert.True(CxSastScans.NormalizeDateParse(null).Equals(DateTime.MinValue));
+        }
+
+        [Test]
+        public void IsoStringExpectIsoDate()
+        {
+            String dt = "2020-08-31T01:01:01Z";
+            Assert.True(CxSastScans.NormalizeDateParse(dt).Equals(DateTime.Parse (dt)));
+        }
+    }
+}

--- a/SPEC.md
+++ b/SPEC.md
@@ -10,6 +10,8 @@ using OSA.)
 
 * CxVersion
 * DeepLink
+* EngineFinished
+* EngineStart
 * FailedLinesOfCode
 * FileCount
 * Information

--- a/TransformLogic/PropertyKeys.cs
+++ b/TransformLogic/PropertyKeys.cs
@@ -23,5 +23,7 @@ namespace CxAnalytix.TransformLogic
         public static readonly String KEY_SIMILARITYID = "SimilarityId";
         public static readonly String KEY_INSTANCEID = "InstanceId";
         public static readonly String KEY_CUSTOMFIELDS = "CustomFields";
+        public static readonly String KEY_ENGINESTART = "EngineStart";
+        public static readonly String KEY_ENGINEFINISH = "EngineFinished";
     }
 }

--- a/TransformLogic/Transformer.cs
+++ b/TransformLogic/Transformer.cs
@@ -663,6 +663,8 @@ namespace CxAnalytix.TransformLogic
             flat.Add(PropertyKeys.KEY_SCANTYPE, scanRecord.ScanType);
             flat.Add(PropertyKeys.KEY_SCANFINISH, scanRecord.FinishedStamp);
             flat.Add(PropertyKeys.KEY_SCANSTART, SastScanCache[scanRecord.ScanId].StartTime);
+            flat.Add(PropertyKeys.KEY_ENGINESTART, SastScanCache[scanRecord.ScanId].EngineStartTime);
+            flat.Add(PropertyKeys.KEY_ENGINEFINISH, SastScanCache[scanRecord.ScanId].EngineFinishTime);
             flat.Add(PropertyKeys.KEY_SCANRISK, SastScanCache[scanRecord.ScanId].ScanRisk);
             flat.Add(PropertyKeys.KEY_SCANRISKSEV, SastScanCache[scanRecord.ScanId].ScanRiskSeverity);
             flat.Add("LinesOfCode", SastScanCache[scanRecord.ScanId].LinesOfCode);


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ts/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Non-US Locale ended with date-time string parsing issues and now works. This was tested with Australia Date-Time format.

### References

> https://github.com/checkmarx-ts/CxAnalytix/issues/20

### Testing

> A private release with the hotfix was created on US-East Servers.
> The private release was then tested on Australia East (AEST).
> Date-Time parsing do not appear with this release.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
